### PR TITLE
Fix `Reference Errror: rowIndex is not defined` exception

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -141,8 +141,7 @@ class MuiTable extends Component {
                           active={
                             orderBy &&
                             (orderBy === column.name ||
-                              orderBy === column.orderBy) &&
-                            rowIndex === 0
+                              orderBy === column.orderBy)
                           }
                           style={{ width: 'inherit' }} // fix text overflowing
                           direction={orderDirection}


### PR DESCRIPTION
@techniq Got this error when upgrading to v 2.0.0. 

Might be also worth adding a test/demo with clickable column headers and `orderBy` set